### PR TITLE
BUGFIX - Add Payment, Get Payment, Delete Payment

### DIFF
--- a/components/payments/payment-modal.js
+++ b/components/payments/payment-modal.js
@@ -5,6 +5,8 @@ import Modal from "../modal"
 export default function AddPaymentModal({ showModal, setShowModal, addNewPayment }) {
   const merchantNameInput = useRef()
   const acctNumInput = useRef()
+  const expDate = useRef()
+
   return (
     <Modal showModal={showModal} setShowModal={setShowModal} title="Add New Payment Method">
       <>
@@ -20,14 +22,24 @@ export default function AddPaymentModal({ showModal, setShowModal, addNewPayment
           label="Account Number"
           refEl={acctNumInput}
         />
+        <Input 
+          id="paymentDate"
+          type="date"
+          label="Expiration Date"
+          refEl={expDate}
+        />
       </>
       <>
         <button
           className="button is-success"
-          onClick={() => addNewPayment({
-            acctNumber: acctNumInput.current.value,
-            merchant: merchantNameInput.current.value
-          })}
+          onClick={() => {
+            const rawDate = new Date(expDate.current.value);
+            const formattedDate = `${rawDate.getFullYear()}-${(rawDate.getMonth() + 1).toString().padStart(2, '0')}-${rawDate.getDate().toString().padStart(2, '0')}`;
+            addNewPayment({
+            account_number: acctNumInput.current.value,
+            merchant_name: merchantNameInput.current.value,
+            expiration_date: formattedDate
+          })}}
         >Add Payment Method</button>
         <button className="button" onClick={() => setShowModal(false)}>Cancel</button>
       </>

--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse, fetchWithoutResponse } from "./fetcher";
 
 export function getPaymentTypes() {
-  return fetchWithResponse('payment-types', {
+  return fetchWithResponse('paymenttypes', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -9,7 +9,7 @@ export function getPaymentTypes() {
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
+  return fetchWithResponse(`paymenttypes`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -20,7 +20,7 @@ export function addPaymentType(paymentType) {
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`


### PR DESCRIPTION
The purpose of this pull request is to fix a few bugs that kept the application's "Payment Methods" page from working at all

**Changes**
• in the payment-types.js module, the endpoint arguments for all three fetch functions were changed from 'payment-types' to 'paymenttypes' to meet required route expectation in the API. This alone fixed the issues for dleteing and getting payment  types

• in the payment-modal.js module, a expiration date input was added with functionality to format/store date state, and the addNewPayment() function's object argument was corrected to meet API expectations

**Testing**
• Run the API debugger and run the client application
• Log in with a registered user that already has atleast one payment type in the database
• Navigate to the 'Payment Methods' page via the dropdown menu on the navbar
• When the page loads, confirm that all of the logged in user's payment types are listed (reference 'bangazon_payment' table in database)
• Click the 'Add New Payment' button and a form should pop up to add a payment. Fill in all three fields, and click the 'Add Payment Method' button.
•The page should refresh and you should see all of the user's payment methods with the new method included. Double check the database to ensure it was added there
• Now click the trash can icon next to the method you just created, and the page should refresh and the payment will be removed. Double check the database to ensure that it was removed