### PR TITLE
Displayed order information on My Orders page #2

### DIFF
--- a/data/auth.js
+++ b/data/auth.js
@@ -1,29 +1,29 @@
-import { fetchWithResponse } from "./fetcher"
+import { fetchWithResponse } from "./fetcher";
 
 export function login(user) {
-  return fetchWithResponse('login', {
-    method: 'POST',
+  return fetchWithResponse("login", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(user)
-  })
+    body: JSON.stringify(user),
+  });
 }
 
 export function register(user) {
-  return fetchWithResponse('register', {
-    method: 'POST',
+  return fetchWithResponse("register", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(user)
-  })
+    body: JSON.stringify(user),
+  });
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('profile', {
+  return fetchWithResponse("profile", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-    }
-  })
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
+  });
 }

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -1,40 +1,42 @@
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import Table from '../components/table'
-import { getOrders } from '../data/orders'
+import { useEffect, useState } from "react";
+import CardLayout from "../components/card-layout";
+import Layout from "../components/layout";
+import Navbar from "../components/navbar";
+import Table from "../components/table";
+import { getOrders } from "../data/orders";
 
 export default function Orders() {
-  const [orders, setOrders] = useState([])
-  const headers = ['Order Date', 'Total', 'Payment Method']
+  const [orders, setOrders] = useState([]);
+  const headers = ["Order #", "Order Date", "Total", "Payment Method"];
 
   useEffect(() => {
-    getOrders().then(ordersData => {
+    getOrders().then((ordersData) => {
       if (ordersData) {
-        setOrders(ordersData)
+        setOrders(ordersData);
       }
-    })
-  }, [])
+    });
+  }, []);
 
   return (
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
-          {
-            orders.map((order) => (
-              <tr key={order.id}>
-                <td>{order.completed_on}</td>
-                <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
-              </tr>
-            ))
-          }
+          {orders.map((order) => (
+            <tr key={order.id}>
+              <td>{order.id}</td>
+              <td>{order.created_date}</td>
+              <td>${order.total_price}</td>
+              <td>
+                {order.payment_type?.merchant_name}{" "}
+                {order.payment_type?.obscured_num}
+              </td>
+            </tr>
+          ))}
         </Table>
         <></>
       </CardLayout>
     </>
-  )
+  );
 }
 
 Orders.getLayout = function getLayout(page) {
@@ -43,5 +45,5 @@ Orders.getLayout = function getLayout(page) {
       <Navbar />
       <section className="container">{page}</section>
     </Layout>
-  )
-}
+  );
+};


### PR DESCRIPTION
After adding the total_price field and payment information to the response from the API, I accessed the relevant information in the return block to display order id, order total, order date, and the payment information with an obscured account number. 

## Changes
- Added a new header to display another column header labelled "Order #"
- Added JSX expressions to render order id, total price, date, and payment fields for each order

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

## Testing

- [ ] Log in as either Joe Shepherd or Jisie David. The usernames are joe and jisie, respectively. These are the users with completed orders.
- [ ] Navigate to "My Orders" in the profile drop-down
- [ ] You should see something like this:
Order # | Order Date | Total | Payment Method
1 | 2019-08-16 | $0 | Visa **************439
3 | 2019-03-26 | $2962.33 | Visa **************439
6 | 2019-07-01 | $0 | Visa **************439
- [ ] If every field is populated, the test is successful.


## Related Issues
- Fixes ticket #2 