### PR TITLE
BUGFIX - Complete order - Ticket #4

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -16,13 +16,13 @@ export function getOrders() {
   })
 }
 
-export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+export function completeCurrentOrder(orderId, payment_type) {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify({payment_type})
   })
 }


### PR DESCRIPTION
• The purpose of this pull request fix a bug that prevented the user from successfully completing their order
• Ticket #4 

**Changes**
• The argument for CompleteCurrentOrder() was changed to meet the request expectation of the API for 'payment_id'

**Test**
• Run the API debugger and then run the client side application
• Log in with a user that currently has an open order(check the database orders for NULL payment type to indicate open order). If no orders are currently open in your database, re-seed it with your original fixtures using ./seed_data.sh
• Once logged in, navigate to the Cart via the dropdown menu. It should be populated with the open order items.
• Click 'Complete Order' and choose payment type, then click 'Complete Order'
• You should be redirected to the my-orders page, and the order you just completed should be listed with a payment type.
• Please confirm in the database that the order's payment type was indeed updated from NULL to your payment selection