### PR TITLE
Bugfix - cart error - Ticket #43

### DIFF
--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -32,3 +32,12 @@ export const fetchWithResponse = (resource, options) => fetch(`${API_URL}/${reso
 export const fetchWithoutResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
   .then(checkError)
   .catch(catchError)
+
+export const fetchIgnore404 = (resource, options) => fetch(`${API_URL}/${resource}`, options)
+  .then((res) => {
+    if (res.status === 404) {
+      return res.json()
+    } else {
+      return checkErrorJson(res).catch(catchError)
+    }
+  })

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
-import { fetchWithResponse } from "./fetcher";
+import { fetchWithResponse, fetchIgnore404 } from "./fetcher";
 
 export function getCart() {
-  return fetchWithResponse("cart", {
+  return fetchIgnore404("cart", {
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
     },


### PR DESCRIPTION
• The purpose of this pull request is to fix a bug that exists on the "cart" route of the application. 
• If a users cart becomes empty, either by deleting it or completing the order, or simply not having a cart to begin with....and navigates to the cart view, a 404 error is displayed.

**Related issues**
Ticket #43 

**Changes**
• In the fetcher file, a new function was created to make handle fetch requests when a 404 could be expected(such as an empty cart, meaning the server failed to find an open order). The function will still catch other errors as needed
• The new fetchIgnore404 function was then implemented in the getCart function on orders.js

**Test**
• Run the development server and log in to the application with any user
• Navigate to the cart via the dropdown menu - if logged in user has an open cart it should display, if user has no items in there cart, then there should simply be no items listed on the page and no errors shown. 
• Now add a product to the cart and you should be navigated to the cart view, where you see that item. Now click delete order and your cart should be emptied without any display of error.
• lastly, add another product and complete the order (you will be taken to orders view). Navigate back to your now empty cart, and there should be no items and no displayed errors
