### PR TITLE
Feature - favorite/unfavorite store - Ticket #21

### DIFF
--- a/data/stores.js
+++ b/data/stores.js
@@ -38,13 +38,14 @@ export function editStore(store) {
   });
 }
 
-export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/favorite`, {
+export function favoriteStore(store) {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: "POST",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
       "Content-Type": "application/json",
     },
+    body: JSON.stringify(store)
   });
 }
 

--- a/data/stores.js
+++ b/data/stores.js
@@ -49,12 +49,13 @@ export function favoriteStore(store) {
   });
 }
 
-export function unfavoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/unfavorite`, {
+export function unfavoriteStore(store) {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: "DELETE",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
       "Content-Type": "application/json",
     },
+    body: JSON.stringify(store)
   });
 }

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -42,7 +42,10 @@ export default function StoreDetail() {
   }
 
   const unfavorite = () => {
-    unfavoriteStore(id).then(refresh)
+    const store = {
+      "store_id": id
+    }
+    unfavoriteStore(store).then(refresh)
   }
 
   return (

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -35,7 +35,10 @@ export default function StoreDetail() {
   }
 
   const favorite = () => {
-    favoriteStore(id).then(refresh)
+    const store = {
+      "store_id": id
+    }
+    favoriteStore(store).then(refresh)
   }
 
   const unfavorite = () => {


### PR DESCRIPTION
• The purpose of this pull request is to add the ability for the client application to favorite/unfavorite a store
• Ticket #21 

**Changes**
• in pages/stores/[id]/index.js the functions favorite and unfavorite were updated to pass an object with the store_id as an argument
• in data/stores.js, the endpoints and body were updated accordingly to meet api expectations

**Test**
• Run the development server and client application.
• log in with any user, and navigate to the stores page, then click on a stores detail view
• In this detail view, there will either be a favorite or unfavorite button depending on whether or not there is a favorite instance in your database for the logged in user and this store. Click on the button, and it should switch to the opposite (favorite/infavorite)
• Confirm in your database that a Favorite instance was either created or delete as expected for your case